### PR TITLE
ci: build static webpate

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -1,0 +1,48 @@
+name: gh-pages
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build_and_deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Setup Pages
+      uses: actions/configure-pages@v3
+
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+
+    - name: Run make
+      run: make
+
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v1
+      with:
+        path: 'build'
+
+    - name: Deploy to GitHub Pages
+      id: deployment
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      uses: actions/deploy-pages@v2

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -44,5 +44,4 @@ jobs:
 
     - name: Deploy to GitHub Pages
       id: deployment
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: actions/deploy-pages@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 index.html
+build/index.html

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,7 +80,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         // more checks to be added
     } else {
         terms.sort_terms().to_file(path)?;
-        build_static_page(terms, "index.html");
+        build_static_page(terms, "build/index.html");
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

* use a separate yaml file to handle deployment
* move built website into `build` so we don't need to upload the whole repo. Also make it cleaner when we need to add javascipt to the page later
* Demo can be seen here: (tried deploying on my forked repo): https://antoncoding.github.io/Terms/

## Finding the URL
* go to settings -> page
<br />

![Screenshot 2023-06-20 at 12 49 04](https://github.com/EtherTW/Terms/assets/20136488/ea72a180-93db-4090-bc75-2559d8114f34)
