### PR TITLE
feat: add tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@
 
 1. 請在 `terms.toml` 文件中按字母順序加入你的翻譯。每一行代表一個專有名詞，格式如下：
 
-
    - TOML 格式：
-     ```
+
+     ```toml
      [[terms]]
      term = "英文專有名詞"
+     tags = ["tag1", "tag2"]
      translation = "中文翻譯"
      ```
 

--- a/build/search.js
+++ b/build/search.js
@@ -1,0 +1,17 @@
+$(document).ready(function(){
+  $("#searchInput").on("keyup", function() {
+    applyFilters();
+  });
+});
+
+function applyFilters() {
+  var searchValue = $("#searchInput").val().toLowerCase();
+  var tagFilter = window.tagFilter;  // Current tag filter from tags.js
+  
+  $("#termsTable tr").each(function() {
+    var row = $(this);
+    var matchesSearch = row.text().toLowerCase().indexOf(searchValue) > -1;
+    var matchesTag = tagFilter == null || row.text().indexOf(tagFilter) > -1;
+    row.toggleClass('filtered', matchesSearch && matchesTag);
+  });
+}

--- a/build/tags.js
+++ b/build/tags.js
@@ -1,0 +1,53 @@
+const colors = ["secondary", "success", "danger", "warning", "primary", "info", "light", "dark"];
+
+/**
+ * setup colorMap[tag] => color
+ * @param {*} tags 
+ * @returns 
+ */
+function createColorMap(tags) {
+  let colorMap = {};
+  for (let i = 0; i < tags.length; i++) {
+    colorMap[tags[i]] = colors[i % colors.length];
+  }
+  return colorMap;
+}
+
+$(document).ready(function() {
+  let tags = ["mev", "zk", "defi", "protocol", "layer2"];
+  let colorMap = createColorMap(tags);
+  // Now you can use colorMap to set the colors of your badges
+  $(".badge").each(function() {
+    let tag = $(this).text();
+    $(this).addClass("badge-" + colorMap[tag]);
+  });
+
+  // Save reference to all table rows
+  let rows = $("#termsTable tbody tr");
+
+  // Apply colors to tags
+  $(document).ready(function() {
+      $(".badge").each(function() {
+          let tag = $(this).text();
+          $(this).addClass("badge-" + colorMap[tag]);
+      });
+
+      // Make tags clickable
+      $(".badge").click(function() {
+        window.tagFilter = $(this).text();
+        applyFilters();
+      });
+
+  });
+
+  // Reset filtered tag button functionality
+  $("#resetButton").click(function() {
+    window.tagFilter = null;
+    $("#searchInput").val("");
+    applyFilters();
+  });
+
+  // Initially, all rows are filtered
+  rows.addClass('filtered');
+});
+

--- a/build/template.html
+++ b/build/template.html
@@ -18,6 +18,16 @@
         width: 100%;
         text-align: center;
       }
+      .badge {
+        opacity: 70%;
+      }
+      #termsTable tbody tr {
+        display: none;
+      }
+
+      #termsTable tbody tr.filtered {
+        display: table-row;
+      }
     </style>
 </head>
 <body class="d-flex flex-column h-100">
@@ -32,11 +42,18 @@
                 <!-- Search bar -->
                 <input class="form-control" id="searchInput" type="text" placeholder="Search..">
                 <br>
+                <!-- Reset Button -->
+                <div class="d-flex justify-content-end mb-2">
+                  <button type="button" class="btn btn-sm btn-outline-secondary" id="resetButton">Reset filter</button>
+                </div>
+                <br>
+                <!-- Table -->
                 <table class="table table-striped" id="termsTable">
                     <thead>
                       <tr>
                         <th scope="col">English Term</th>
                         <th scope="col">中文</th>
+                        <th scope="col">Tags</th>
                       </tr>
                     </thead>
                     <tbody>
@@ -52,22 +69,15 @@
     <footer class="footer mt-auto py-3 bg-light">
         <div class="container">
             <span class="text-muted">Made with ❤️ by <a href="https://twitter.com/eth_taipei" target="_blank">Taipei Ethereum</a> @ <a href="https://github.com/EtherTW/Terms/blob/main/LICENSE" target="_blank">MIT</a>.</span>
-
         </div>
     </footer>
     <!-- JS, Popper.js, and jQuery -->
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
-    <script>
-    $(document).ready(function(){
-      $("#searchInput").on("keyup", function() {
-        var value = $(this).val().toLowerCase();
-        $("#termsTable tr").filter(function() {
-          $(this).toggle($(this).text().toLowerCase().indexOf(value) > -1)
-        });
-      });
-    });
-    </script>
+
+    <!-- Load custom scripts after loading jQuery -->
+    <script src="./search.js"></script> 
+    <script src="./tags.js"></script>
 </body>
 </html>

--- a/src/html_builder.rs
+++ b/src/html_builder.rs
@@ -10,6 +10,16 @@ fn generate_terms_table(terms: &Terms) -> String {
         table.push_str("<tr>");
         table.push_str(&format!("<td>{}</td>", term.term));
         table.push_str(&format!("<td>{}</td>", term.translation));
+        // cell for tags
+        table.push_str("<td>");
+        for tag in &term.tags {
+            // Each tag is a span with the class "badge" and a unique class based on the tag's name (id)
+            table.push_str(&format!(
+                "<span class='badge badge-{}'>{}</span> ",
+                tag, tag
+            ));
+        }
+        table.push_str("</td>");
         table.push_str("</tr>\n");
     }
     table

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let check_only = args.len() > 1 && args[1] == "--check";
 
     let path = "terms.toml";
-    let mut terms = Terms::from_file(path)?;
+    let mut terms = Terms::load_terms(path)?;
 
     if check_only {
         // check #1: make sure terms are all sorted
@@ -21,7 +21,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         if terms != expected {
             panic!("terms.toml is not sorted");
         }
-        // more checks to be added
+        // check #2: make sure all tags are valid
+        Terms::check_all_tags(&terms.terms)?;
     } else {
         terms.sort_terms();
         terms.to_file(path)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ mod html_builder;
 mod terms;
 
 use html_builder::build_static_page;
-use terms::Terms;
+use terms::{Tags, Terms};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let args: Vec<String> = env::args().collect();
@@ -22,7 +22,8 @@ fn main() -> Result<(), Box<dyn Error>> {
             panic!("terms.toml is not sorted");
         }
         // check #2: make sure all tags are valid
-        Terms::check_all_tags(&terms.terms)?;
+        let tags = Tags::load_tags("tags.toml")?;
+        terms.check_all_tags(tags)?;
     } else {
         terms.sort_terms();
         terms.to_file(path)?;

--- a/src/terms.rs
+++ b/src/terms.rs
@@ -6,6 +6,7 @@ use toml::{from_str, to_string};
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct Term {
     pub term: String,
+    pub tags: Vec<String>,
     pub translation: String,
 }
 
@@ -14,11 +15,45 @@ pub struct Terms {
     pub terms: Vec<Term>,
 }
 
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
+pub struct Tag {
+    pub id: String,
+    pub description: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
+pub struct Tags {
+    pub tags: Vec<Tag>,
+}
+
 impl Terms {
-    pub fn from_file(path: &str) -> Result<Self, Box<dyn Error>> {
+    pub fn load_terms(path: &str) -> Result<Self, Box<dyn Error>> {
         let contents = read_to_string(path)?;
         let terms: Terms = from_str(&contents)?;
         Ok(terms)
+    }
+
+    /// takes in terms, load tags and check if there's any illegal tags
+    pub fn check_all_tags(terms: &[Term]) -> Result<(), Box<dyn Error>> {
+        let contents = read_to_string("tags.toml")?;
+        let tags: Tags = from_str(&contents)?;
+        for term in terms {
+            for tag in &term.tags {
+                if !Self::check_tag(tag, &tags.tags) {
+                    panic!("Illegal tag '{}' in term '{}'", tag, term.term);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn check_tag(tag: &str, tags: &[Tag]) -> bool {
+        for valid_tag in tags {
+            if &valid_tag.id == tag {
+                return true;
+            }
+        }
+        false
     }
 
     /// Sort the terms alphabetically by term

--- a/src/terms.rs
+++ b/src/terms.rs
@@ -34,26 +34,15 @@ impl Terms {
     }
 
     /// takes in terms, load tags and check if there's any illegal tags
-    pub fn check_all_tags(terms: &[Term]) -> Result<(), Box<dyn Error>> {
-        let contents = read_to_string("tags.toml")?;
-        let tags: Tags = from_str(&contents)?;
-        for term in terms {
+    pub fn check_all_tags(&self, tags: Tags) -> Result<(), Box<dyn Error>> {
+        for term in &self.terms {
             for tag in &term.tags {
-                if !Self::check_tag(tag, &tags.tags) {
+                if !tags.check_tag(tag) {
                     panic!("Illegal tag '{}' in term '{}'", tag, term.term);
                 }
             }
         }
         Ok(())
-    }
-
-    pub fn check_tag(tag: &str, tags: &[Tag]) -> bool {
-        for valid_tag in tags {
-            if valid_tag.id == tag {
-                return true;
-            }
-        }
-        false
     }
 
     /// Sort the terms alphabetically by term
@@ -66,5 +55,22 @@ impl Terms {
         let contents = to_string(self)?;
         write(path, contents)?;
         Ok(())
+    }
+}
+
+impl Tags {
+    pub fn load_tags(path: &str) -> Result<Self, Box<dyn Error>> {
+        let contents = read_to_string(path)?;
+        let tags: Tags = from_str(&contents)?;
+        Ok(tags)
+    }
+
+    pub fn check_tag(&self, tag: &str) -> bool {
+        for valid_tag in &self.tags {
+            if valid_tag.id == tag {
+                return true;
+            }
+        }
+        false
     }
 }

--- a/src/terms.rs
+++ b/src/terms.rs
@@ -49,7 +49,7 @@ impl Terms {
 
     pub fn check_tag(tag: &str, tags: &[Tag]) -> bool {
         for valid_tag in tags {
-            if &valid_tag.id == tag {
+            if valid_tag.id == tag {
                 return true;
             }
         }

--- a/tags.toml
+++ b/tags.toml
@@ -1,0 +1,19 @@
+[[tags]]
+id = "mev"
+description = "Maximal extractable value"
+
+[[tags]]
+id = "zk"
+description = "Zero Knowledge Proofs"
+
+[[tags]]
+id = "defi"
+description = "Decentralized Finance"
+
+[[tags]]
+id = "protocol"
+description = "Ethereum Protocol"
+
+[[tags]]
+id = "layer2"
+description = "Layer 2"

--- a/terms.toml
+++ b/terms.toml
@@ -1,55 +1,69 @@
 [[terms]]
 term = "Back-run, Backrun, Backrunning"
+tags = ["mev"]
 translation = "尾隨交易"
 
 [[terms]]
 term = "Builder"
+tags = ["mev"]
 translation = "區塊建造者"
 
 [[terms]]
 term = "Bundle"
+tags = ["mev"]
 translation = "交易同捆包"
 
 [[terms]]
 term = "Front-run, Frontrun, Frontrunning"
+tags = ["mev"]
 translation = "搶跑交易、搶先交易"
 
 [[terms]]
 term = "Full Node"
+tags = ["protocol"]
 translation = "全節點"
 
 [[terms]]
 term = "Impermanent Loss"
+tags = ["defi"]
 translation = "無常損失"
 
 [[terms]]
 term = "Merkle Tree"
+tags = []
 translation = "雜湊樹"
 
 [[terms]]
 term = "MEV Searcher"
+tags = ["mev"]
 translation = "尋利者"
 
 [[terms]]
 term = "Nullifier"
+tags = ["zk"]
 translation = "註銷碼"
 
 [[terms]]
 term = "Proof of Stake, PoS"
+tags = ["protocol"]
 translation = "權益證明"
 
 [[terms]]
 term = "Proposer"
+tags = ["protocol"]
 translation = "區塊發佈者"
 
 [[terms]]
 term = "Sandwich Attack"
+tags = ["mev"]
 translation = "三明治夾擊"
 
 [[terms]]
 term = "Slash, Slashing"
+tags = ["protocol"]
 translation = "懲罰、罰款"
 
 [[terms]]
 term = "Validator"
+tags = ["protocol"]
 translation = "驗證者"


### PR DESCRIPTION
## Summary

* Add `tags.toml`
* Check all tags in terms are legal, when the `-- --check` flag is provided
* Show tags on static page, each badge is clickable and will filter table to only show rows with the tag
* Refactor the js code and move them to separate js files.

## Details
* demo can be found here: https://antoncoding.github.io/Terms/
* both `tags.js` and `seach.js` filter the table at the same time, that's why we need an extra `filtered` class for each row to compound the effect. for example: If you type something in the search bar and then click on one tag, it only shows you rows fitting the search result + filtered by tag.
* This will resolve the last checkbox defined in #9 
