### PR TITLE
feat: markdown link

### DIFF
--- a/src/html_builder.rs
+++ b/src/html_builder.rs
@@ -1,6 +1,7 @@
 use std::error::Error;
 use std::fs::{self, File};
 use std::io::Write;
+use regex::Regex;
 
 use crate::terms::Terms;
 
@@ -25,12 +26,47 @@ fn generate_terms_table(terms: &Terms) -> String {
         }
         table.push_str(&format!(
             "<td>{}</td>",
-            term.context.clone().unwrap_or_default()
+            parse_markdown_link(term.context.clone().unwrap_or_default())
         ));
         table.push_str("</td>");
         table.push_str("</tr>\n");
     }
     table
+}
+
+
+fn parse_markdown_link(context: String) -> String {
+    let re = Regex::new(r"\[([^\]]+)\]\(([^)]+)\)").unwrap();
+    let mut last_end = 0;
+    let mut context_field = String::new();
+
+    for cap in re.captures_iter(&context) {
+        let link_text = &cap[1];
+        let link = &cap[2];
+        let start = cap.get(0).unwrap().start();
+        let end = cap.get(0).unwrap().end();
+
+        // Push the text up to the link
+        context_field.push_str(&context[last_end..start]);
+
+        // Shorten the link text if it is too long
+        let display_text = if link_text.len() > 10 {
+            format!("{}...", &link_text[..10])
+        } else {
+            link_text.to_string()
+        };
+
+        // Insert the HTML link
+        context_field.push_str(&format!("<a href='{}' target=\"_blank\">{}</a>", link, display_text));
+
+        // Update the last_end to the end of the current match
+        last_end = end;
+    }
+
+    // Append any remaining text after the last link
+    context_field.push_str(&context[last_end..]);
+
+    context_field
 }
 
 pub fn build_static_page(terms: &Terms, output_path: &str) -> Result<(), Box<dyn Error>> {
@@ -40,4 +76,17 @@ pub fn build_static_page(terms: &Terms, output_path: &str) -> Result<(), Box<dyn
     let mut output_file = File::create(output_path)?;
     write!(output_file, "{}", template)?;
     Ok(())
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_markdown_link() {
+        let context = "2 links in text [link](https://example.com) [link2](https://example2.com) and some more text.";
+        let expected = "2 links in text <a href='https://example.com' target=\"_blank\">link</a> <a href='https://example2.com' target=\"_blank\">link2</a> and some more text.";
+        assert_eq!(parse_markdown_link(context.to_string()), expected);
+    }
 }

--- a/src/html_builder.rs
+++ b/src/html_builder.rs
@@ -1,7 +1,7 @@
+use regex::Regex;
 use std::error::Error;
 use std::fs::{self, File};
 use std::io::Write;
-use regex::Regex;
 
 use crate::terms::Terms;
 
@@ -74,7 +74,10 @@ fn parse_markdown_link(context: String) -> String {
         };
 
         // Insert the HTML link
-        context_field.push_str(&format!("<a href='{}' target=\"_blank\">{}</a>", link, display_text));
+        context_field.push_str(&format!(
+            "<a href='{}' target=\"_blank\">{}</a>",
+            link, display_text
+        ));
 
         // Update the last_end to the end of the current match
         last_end = end;
@@ -85,7 +88,6 @@ fn parse_markdown_link(context: String) -> String {
 
     context_field
 }
-
 
 /// Builds a static HTML page using a template and the provided terms.
 ///

--- a/src/html_builder.rs
+++ b/src/html_builder.rs
@@ -5,6 +5,15 @@ use regex::Regex;
 
 use crate::terms::Terms;
 
+/// Generates an HTML table containing the terms and their translations.
+///
+/// # Arguments
+///
+/// * `terms` - A reference to the `Terms` struct containing the list of terms.
+///
+/// # Returns
+///
+/// A string representing the HTML table.
 fn generate_terms_table(terms: &Terms) -> String {
     let mut table = String::new();
     for term in &terms.terms {
@@ -25,7 +34,7 @@ fn generate_terms_table(terms: &Terms) -> String {
             ));
         }
         table.push_str(&format!(
-            "<td>{}</td>",
+            "<td> {} </td>",
             parse_markdown_link(term.context.clone().unwrap_or_default())
         ));
         table.push_str("</td>");
@@ -34,7 +43,15 @@ fn generate_terms_table(terms: &Terms) -> String {
     table
 }
 
-
+/// Parses markdown links in a string and converts them to HTML links.
+///
+/// # Arguments
+///
+/// * `context` - The string containing markdown links.
+///
+/// # Returns
+///
+/// A string with the markdown links converted to HTML links.
 fn parse_markdown_link(context: String) -> String {
     let re = Regex::new(r"\[([^\]]+)\]\(([^)]+)\)").unwrap();
     let mut last_end = 0;
@@ -69,6 +86,17 @@ fn parse_markdown_link(context: String) -> String {
     context_field
 }
 
+
+/// Builds a static HTML page using a template and the provided terms.
+///
+/// # Arguments
+///
+/// * `terms` - A reference to the `Terms` struct containing the list of terms.
+/// * `output_path` - The path to the output file.
+///
+/// # Returns
+///
+/// A `Result` indicating success or failure. If successful, `Ok(())` is returned.
 pub fn build_static_page(terms: &Terms, output_path: &str) -> Result<(), Box<dyn Error>> {
     let mut template = fs::read_to_string("build/template.html")?;
     let terms_table = generate_terms_table(terms);
@@ -77,7 +105,6 @@ pub fn build_static_page(terms: &Terms, output_path: &str) -> Result<(), Box<dyn
     write!(output_file, "{}", template)?;
     Ok(())
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/terms.toml
+++ b/terms.toml
@@ -85,7 +85,7 @@ term = "Bitcoin Improvement Proposals"
 tags = []
 translation = "比特幣改進提案"
 acronym = "BIPs"
-context = "https://github.com/bitcoin/bips"
+context = "[連結](https://github.com/bitcoin/bips)"
 
 [[terms]]
 term = "Block"
@@ -743,7 +743,7 @@ term = "Scalable Transparent Arguments of Knowledge"
 tags = []
 translation = "可擴展透明知識證明"
 acronym = "STARK"
-context = "來自論文 https://eprint.iacr.org/2018/046"
+context = "來自[論文](https://eprint.iacr.org/2018/046)"
 
 [[terms]]
 term = "Scaling"
@@ -871,8 +871,8 @@ term = "State pruning"
 tags = []
 translation = "狀態剪枝"
 context = """
-當以太坊狀態樹會隨著交易的發生而更動，更動時會產生新的狀態根以及讓樹上某些舊節點失效。狀態剪枝是刪除舊節點以節省硬碟使用的做法。
-https://blog.ethereum.org/2015/06/26/state-tree-pruning/"""
+當以太坊狀態樹會隨著交易的發生而更動，更動時會產生新的狀態根以及讓樹上某些舊節點失效。狀態剪枝是刪除舊節點以節省硬碟使用的做法。[連結](https://blog.ethereum.org/2015/06/26/state-tree-pruning/)
+"""
 
 [[terms]]
 term = "Storage"
@@ -995,7 +995,7 @@ translation = "錢包"
 term = "Warp sync"
 tags = []
 translation = "曲速同步"
-context = "https://openethereum.github.io/Warp-Sync-Snapshot-Format"
+context = "[連結](https://openethereum.github.io/Warp-Sync-Snapshot-Format)"
 
 [[terms]]
 term = "Web3"


### PR DESCRIPTION
## TLDR
Parse markdown link，使用 html <a> tag 取代

## 實作困難
本來想做 1 & 3，但是 1 比想像中難做，於是先做 3

1. 目前的做法是先將 markdown parse 成 html file. 這之後如果要算字數決定是否 shorten text 的時候會遇到一些問題（例如要判斷 `<a />` 不算在字數裡面），不能直接用 length 判斷。
2. static file 難以做到 toggle 兩個不同的 content ，目前嘗試了一些做法都有問題，理想上希望可以完全靠 js & css 解決