### PR TITLE
chore: add new terms

### DIFF
--- a/src/bin/parse_tbx.rs
+++ b/src/bin/parse_tbx.rs
@@ -6,7 +6,7 @@ use std::{
 use regex::Regex;
 use serde::Deserialize;
 use serde_xml_rs::from_str;
-use terms::terms::{Term, Terms};
+use terms::terms::{Term, Terms, ToFile};
 
 #[derive(Debug, Deserialize)]
 struct LangSet {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,9 +5,7 @@ mod html_builder;
 mod terms;
 
 use html_builder::build_static_page;
-use terms::{Tags, Terms};
-
-use crate::terms::to_file;
+use terms::{Tags, Terms, ToFile};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let args: Vec<String> = env::args().collect();
@@ -33,9 +31,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         terms.check_all_tags(tags)?;
     } else {
         terms.sort_terms();
-        to_file(&terms, terms_path)?;
+        terms.to_file(terms_path)?;
         tags.sort_tags();
-        to_file(&tags, tags_path)?;
+        tags.to_file(tags_path)?;
 
         build_static_page(&terms, "build/index.html")?;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,26 +7,36 @@ mod terms;
 use html_builder::build_static_page;
 use terms::{Tags, Terms};
 
+use crate::terms::to_file;
+
 fn main() -> Result<(), Box<dyn Error>> {
     let args: Vec<String> = env::args().collect();
     let check_only = args.len() > 1 && args[1] == "--check";
 
-    let path = "terms.toml";
-    let mut terms = Terms::load_terms(path)?;
+    let terms_path = "terms.toml";
+    let tags_path = "tags.toml";
+    let mut terms = Terms::load_terms(terms_path)?;
+    let mut tags = Tags::load_tags(tags_path)?;
 
     if check_only {
         // check #1: make sure terms are all sorted
-        let expected = terms.clone();
+        let expected_terms = terms.clone();
         terms.sort_terms();
-        if terms != expected {
-            panic!("terms.toml is not sorted");
-        }
-        // check #2: make sure all tags are valid
-        let tags = Tags::load_tags("tags.toml")?;
+        assert!(terms == expected_terms, "terms.toml is not sorted");
+
+        // check #2: make sure all tags are all sorted
+        let expected_tags = tags.clone();
+        tags.sort_tags();
+        assert!(tags == expected_tags, "tags.toml is not sorted");
+
+        // check #3: make sure all tags are valid
         terms.check_all_tags(tags)?;
     } else {
         terms.sort_terms();
-        terms.to_file(path)?;
+        to_file(&terms, terms_path)?;
+        tags.sort_tags();
+        to_file(&tags, tags_path)?;
+
         build_static_page(&terms, "build/index.html")?;
     }
 

--- a/src/terms.rs
+++ b/src/terms.rs
@@ -3,6 +3,16 @@ use std::error::Error;
 use std::fs::{read_to_string, write};
 use toml::{from_str, to_string};
 
+pub trait ToFile: Serialize {
+    fn to_file(&self, path: &str) -> Result<(), Box<dyn Error>> {
+        let contents = to_string(self)?;
+        write(path, contents)?;
+        Ok(())
+    }
+}
+
+impl<T: Serialize> ToFile for T {}
+
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct Term {
     pub term: String,
@@ -26,13 +36,6 @@ pub struct Tag {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct Tags {
     pub tags: Vec<Tag>,
-}
-
-/// Generic utility function to serialize any Serialize type to a TOML file
-pub fn to_file<T: Serialize>(data: &T, path: &str) -> Result<(), Box<dyn Error>> {
-    let contents = to_string(data)?;
-    write(path, contents)?;
-    Ok(())
 }
 
 impl Terms {

--- a/src/terms.rs
+++ b/src/terms.rs
@@ -17,15 +17,22 @@ pub struct Terms {
     pub terms: Vec<Term>,
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct Tag {
     pub id: String,
     pub description: String,
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct Tags {
     pub tags: Vec<Tag>,
+}
+
+/// Generic utility function to serialize any Serialize type to a TOML file
+pub fn to_file<T: Serialize>(data: &T, path: &str) -> Result<(), Box<dyn Error>> {
+    let contents = to_string(data)?;
+    write(path, contents)?;
+    Ok(())
 }
 
 impl Terms {
@@ -52,12 +59,6 @@ impl Terms {
         self.terms
             .sort_by(|a, b| a.term.to_lowercase().cmp(&b.term.to_lowercase()));
     }
-
-    pub fn to_file(&self, path: &str) -> Result<(), Box<dyn Error>> {
-        let contents = to_string(self)?;
-        write(path, contents)?;
-        Ok(())
-    }
 }
 
 impl Tags {
@@ -74,5 +75,10 @@ impl Tags {
             }
         }
         false
+    }
+
+    pub fn sort_tags(&mut self) {
+        self.tags
+            .sort_by(|a, b| a.id.to_lowercase().cmp(&b.id.to_lowercase()));
     }
 }

--- a/tags.toml
+++ b/tags.toml
@@ -1,23 +1,35 @@
 [[tags]]
-id = "mev"
-description = "Maximal extractable value"
-
-[[tags]]
-id = "zk"
-description = "Zero Knowledge Proofs"
+id = "cryptography"
+description = "Cryptography"
 
 [[tags]]
 id = "defi"
 description = "Decentralized Finance"
 
 [[tags]]
-id = "protocol"
-description = "Ethereum Protocol"
+id = "ens"
+description = "Ethereum Name Service"
+
+[[tags]]
+id = "l2"
+description = "Layer 2"
 
 [[tags]]
 id = "layer2"
 description = "Layer 2"
 
 [[tags]]
-id = "cryptography"
-description = "Cryptography"
+id = "mev"
+description = "Maximal extractable value"
+
+[[tags]]
+id = "protocol"
+description = "Ethereum Protocol"
+
+[[tags]]
+id = "rollup"
+description = "Rollup"
+
+[[tags]]
+id = "zk"
+description = "Zero Knowledge Proofs"

--- a/terms.toml
+++ b/terms.toml
@@ -149,6 +149,16 @@ translation = "中央化交易所"
 acronym = "CEX"
 
 [[terms]]
+term = "Chain Abstraction"
+tags = []
+translation = "鏈抽象"
+
+[[terms]]
+term = "Chain Identifier"
+tags = []
+translation = "鏈標識符"
+
+[[terms]]
 term = "Chaumian Blinding"
 tags = []
 translation = "喬姆盲簽"
@@ -245,6 +255,11 @@ tags = []
 translation = "合約創建交易"
 
 [[terms]]
+term = "Credibly Neutral"
+tags = []
+translation = "可信中立"
+
+[[terms]]
 term = "Crosslink"
 tags = []
 translation = "交聯"
@@ -263,6 +278,11 @@ translation = "密碼經濟學"
 term = "Dai"
 tags = []
 translation = "Dai"
+
+[[terms]]
+term = "Decentralization"
+tags = []
+translation = "去中心化"
 
 [[terms]]
 term = "Decentralized application"
@@ -538,6 +558,11 @@ tags = []
 translation = "密鑰存儲檔案"
 
 [[terms]]
+term = "L2 Agnostic"
+tags = ["rollup", "l2", "ens"]
+translation = "L2 中立"
+
+[[terms]]
 term = "Last-in-first-out"
 tags = []
 translation = "後進先出法"
@@ -695,6 +720,11 @@ tags = []
 translation = "預言機"
 
 [[terms]]
+term = "Permissionless"
+tags = []
+translation = "無許可"
+
+[[terms]]
 term = "Plasma"
 tags = []
 translation = "Plasma"
@@ -733,6 +763,11 @@ tags = ["protocol"]
 translation = "區塊發佈者"
 
 [[terms]]
+term = "Protocol"
+tags = []
+translation = "協議"
+
+[[terms]]
 term = "Prysm"
 tags = []
 translation = "Prysm"
@@ -769,9 +804,24 @@ tags = []
 translation = "冗餘"
 
 [[terms]]
+term = "Registry"
+tags = ["ens"]
+translation = "註冊表"
+
+[[terms]]
+term = "Resolver"
+tags = ["ens"]
+translation = "解析器"
+
+[[terms]]
 term = "Rollup"
 tags = []
 translation = "卷軸"
+
+[[terms]]
+term = "Rollup Centric"
+tags = ["rollup", "l2"]
+translation = "卷軸中心"
 
 [[terms]]
 term = "RPC"
@@ -784,6 +834,11 @@ tags = ["mev"]
 translation = "三明治夾擊"
 
 [[terms]]
+term = "Scalability"
+tags = []
+translation = "可擴展性"
+
+[[terms]]
 term = "Scalable Transparent Arguments of Knowledge"
 tags = []
 translation = "可擴展透明知識證明"
@@ -794,11 +849,6 @@ context = "來自[論文](https://eprint.iacr.org/2018/046)"
 term = "Scaling"
 tags = []
 translation = "擴展"
-
-[[terms]]
-term = "Scalability"
-tags = []
-translation = "可擴展性"
 
 [[terms]]
 term = "Secure Hash Algorithm"
@@ -850,6 +900,11 @@ translation = "空部位"
 term = "Sidechain"
 tags = []
 translation = "側鏈"
+
+[[terms]]
+term = "Single Point of Failure"
+tags = []
+translation = "單點故障"
 
 [[terms]]
 term = "Slash, Slashing"
@@ -950,6 +1005,11 @@ tags = []
 translation = "強型別"
 
 [[terms]]
+term = "Subname"
+tags = ["ens"]
+translation = "子域名"
+
+[[terms]]
 term = "Succinct non-interactive argument of knowledge"
 tags = []
 translation = "簡潔無互動知識證明"
@@ -999,6 +1059,11 @@ translation = "時間戳記"
 term = "Token"
 tags = []
 translation = "代幣"
+
+[[terms]]
+term = "Top-level Domain, TLD"
+tags = ["ens"]
+translation = "頂級域名"
 
 [[terms]]
 term = "Transaction"
@@ -1106,68 +1171,3 @@ translation = "零知識證明卷軸"
 term = "Zooko's triangle"
 tags = []
 translation = "Zooko 三角"
-
-[[terms]]
-term = "Subname"
-tags = ["ens"]
-translation = "子域名"
-
-[[terms]]
-term = "Decentralization"
-tags = []
-translation = "去中心化"
-
-[[terms]]
-term = "Permissionless"
-tags = []
-translation = "無許可"
-
-[[terms]]
-term = "Credibly Neutral"
-tags = []
-translation = "可信中立"
-
-[[terms]]
-term = "Chain Identifier"
-tags = []
-translation = "鏈標識符"
-
-[[terms]]
-term = "Single Point of Failure"
-tags = []
-translation = "單點故障"
-
-[[terms]]
-term = "Top-level Domain, TLD"
-tags = ["ens"]
-translation = "頂級域名"
-
-[[terms]]
-term = "Chain Abstraction"
-tags = []
-translation = "鏈抽象"
-
-[[terms]]
-term = "Protocol"
-tags = []
-translation = "協議"
-
-[[terms]]
-term = "L2 Agnostic"
-tags = ["rollup", "l2", "ens"]
-translation = "L2 未知論"
-
-[[terms]]
-term = "Registry"
-tags = ["ens"]
-translation = "註冊表"
-
-[[terms]]
-term = "Resolver"
-tags = ["ens"]
-translation = "解析器"
-
-[[terms]]
-term = "Rollup Centric"
-tags = ["rollup", "l2"]
-translation = "卷軸中心"

--- a/terms.toml
+++ b/terms.toml
@@ -373,7 +373,7 @@ acronym = "EIPs"
 
 [[terms]]
 term = "Ethereum Name Service"
-tags = []
+tags = ["ens"]
 translation = "以太坊域名服務"
 acronym = "ENS"
 
@@ -815,7 +815,7 @@ translation = "解析器"
 
 [[terms]]
 term = "Rollup"
-tags = []
+tags = ["rollup", "l2"]
 translation = "卷軸"
 
 [[terms]]

--- a/terms.toml
+++ b/terms.toml
@@ -63,7 +63,7 @@ translation = "基本費用"
 [[terms]]
 term = "Based Rollup"
 tags = []
-translation = "由 L1 排序的 Rollup"
+translation = "由 L1 排序的卷軸"
 
 [[terms]]
 term = "Beacon Chain"
@@ -687,7 +687,7 @@ translation = "運營商"
 [[terms]]
 term = "Optimistic rollup"
 tags = []
-translation = "樂觀卷疊"
+translation = "樂觀卷軸"
 
 [[terms]]
 term = "Oracle"
@@ -771,7 +771,7 @@ translation = "冗餘"
 [[terms]]
 term = "Rollup"
 tags = []
-translation = "Rollup"
+translation = "卷軸"
 
 [[terms]]
 term = "RPC"
@@ -1105,7 +1105,7 @@ translation = "零地址"
 [[terms]]
 term = "Zero-knowledge rollup"
 tags = []
-translation = "零知識證明卷疊"
+translation = "零知識證明卷軸"
 
 [[terms]]
 term = "Zooko's triangle"

--- a/terms.toml
+++ b/terms.toml
@@ -796,14 +796,9 @@ tags = []
 translation = "擴展"
 
 [[terms]]
-term = "Scaling, Scalability"
+term = "Scalability"
 tags = []
-translation = "擴展, 可擴展性"
-
-[[terms]]
-term = "Scaling, Scalability"
-tags = []
-translation = "擴展, 可擴展性"
+translation = "可擴展性"
 
 [[terms]]
 term = "Secure Hash Algorithm"
@@ -1111,3 +1106,68 @@ translation = "零知識證明卷軸"
 term = "Zooko's triangle"
 tags = []
 translation = "Zooko 三角"
+
+[[terms]]
+term = "Subname"
+tags = ["ens"]
+translation = "子域名"
+
+[[terms]]
+term = "Decentralization"
+tags = []
+translation = "去中心化"
+
+[[terms]]
+term = "Permissionless"
+tags = []
+translation = "無許可"
+
+[[terms]]
+term = "Credibly Neutral"
+tags = []
+translation = "可信中立"
+
+[[terms]]
+term = "Chain Identifier"
+tags = []
+translation = "鏈標識符"
+
+[[terms]]
+term = "Single Point of Failure"
+tags = []
+translation = "單點故障"
+
+[[terms]]
+term = "Top-level Domain, TLD"
+tags = ["ens"]
+translation = "頂級域名"
+
+[[terms]]
+term = "Chain Abstraction"
+tags = []
+translation = "鏈抽象"
+
+[[terms]]
+term = "Protocol"
+tags = []
+translation = "協議"
+
+[[terms]]
+term = "L2 Agnostic"
+tags = ["rollup", "l2", "ens"]
+translation = "L2 未知論"
+
+[[terms]]
+term = "Registry"
+tags = ["ens"]
+translation = "註冊表"
+
+[[terms]]
+term = "Resolver"
+tags = ["ens"]
+translation = "解析器"
+
+[[terms]]
+term = "Rollup Centric"
+tags = ["rollup", "l2"]
+translation = "卷軸中心"


### PR DESCRIPTION
## Refactor

- 依循 ethereum.org 翻譯將「卷疊」譯成「卷軸」https://ethereum.org/zh-tw/roadmap/scaling/
- 移除重複的「Scaling, Scalability」

## New Terms

- Subnames
- Decentralization
- Permissionless
- Credibly Neutral
- Chain Identifier
- Single Point of Failure
- Top-level Domain, TLD
- Chain Abstraction
- Protocol
- L2 Agnostic
- Registry
- Resolver
- Rollup Centric